### PR TITLE
QSP-4 Rounding Errors due to Truncation

### DIFF
--- a/contracts/Investment/InvestmentContractV2.sol
+++ b/contracts/Investment/InvestmentContractV2.sol
@@ -71,11 +71,11 @@ contract InvestmentContractV2 is InvestmentContractBase, IInvestmentContract {
     //1. withdraw token from yToken
     uint yTokenBalance = target.yToken.balanceOf(address(this));
     uint price = target.yToken.getPricePerFullShare();
-    uint tokenEarnedBalance = yTokenBalance.mul(price).div(1 ether);
+    uint tokenEarnedBalance = yTokenBalance.div(1 ether).mul(price);
     uint amount = tokenEarnedBalance
       .mul(tokenInvested[tokenAddress][msg.sender])
       .div(target.totalTokenInvested);
-    target.yToken.withdraw(amount.mul(1 ether).div(price));
+    target.yToken.withdraw(amount.div(price).mul(1 ether));
 
     //2. transfer fee
     uint fee = calculateFee(tokenAddress, amount);


### PR DESCRIPTION
**Description**: Within the function _withdrawAll in InvestmentContractV2.sol, multiplication is often performed after division when calculating balance. Performing division first can truncate the decimals of the result, which makes the result imprecise. 

The following lines of code are subjected to this vulnerability:
• Line 75: The variable tokenEarnedBalance is multiplied after it has been obtained by dividing the result of yTokenBalance.mul(price) to 10^18.
• Line 78: The variable amount is multiplied after it has been obtained by dividing the result of tokenEarnedBalance.mul(tokenInvested[tokenAddress]
[msg.sender]) by target.totalTokenInvested.

**Recommendation**: It is recommended to only perform the division operations after all multiplication operations. This seems to be possible as tokenEarnedBalance is a temporary variable.