### PR TITLE
QSP-5 Unchecked Return Values of ERC20 Functions

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -12,6 +12,8 @@ contract Escrow {
   //payment tokens to Payment
   mapping(bytes32 => Payment) public payments; 
 
+  event IERC20TransactionExecuted(address indexed sender, bool indexed success);
+
   function createEthPayment(
     bytes32 _paymentTokenHash 
   ) 
@@ -34,7 +36,8 @@ contract Escrow {
     external 
     payable 
   {
-    IERC20(_tokenAddress).transferFrom(msg.sender, address(this), _value); 
+    bool success = IERC20(_tokenAddress).transferFrom(msg.sender, address(this), _value); 
+    emit IERC20TransactionExecuted(msg.sender, success);
     _createPayment(
       _paymentTokenHash,
       msg.sender,
@@ -68,7 +71,8 @@ contract Escrow {
     if(payment.token == address(0)) {
       _to.transfer(payment.value);
     } else {
-      IERC20(payment.token).transfer(_to, payment.value);
+      bool success =IERC20(payment.token).transfer(_to, payment.value);
+      emit IERC20TransactionExecuted(msg.sender, success);
     }
     payment.sent = true;
   }

--- a/contracts/Investment/InvestmentContractV1.sol
+++ b/contracts/Investment/InvestmentContractV1.sol
@@ -31,6 +31,9 @@ contract InvestmentContractV1 is InvestmentContractBase, IInvestmentContract {
   }
   Target[] public targets;
 
+  event TokenTransactionExecuted(address indexed sender, bool indexed success);
+  event TokenApprovalExecuted(address indexed sender, bool indexed success);
+
   constructor(
     address[] memory _tokens, 
     address[] memory _cTokens, 
@@ -64,11 +67,11 @@ contract InvestmentContractV1 is InvestmentContractBase, IInvestmentContract {
     target.totalTokenInvested = target.totalTokenInvested.add(amount);
 
     //3. send token to this contract
-    target.token.transferFrom(msg.sender, address(this), amount);
-
+    bool success = target.token.transferFrom(msg.sender, address(this), amount);
+    emit TokenTransactionExecuted(msg.sender, success);
     //4. Approve token to be sent to compound
-    target.token.approve(address(target.cToken), amount);
-
+    success = target.token.approve(address(target.cToken), amount);
+    emit TokenApprovalExecuted(msg.sender, success);
     //5. send token to cToken
     assert(target.cToken.mint(amount) == 0);
   }
@@ -89,7 +92,8 @@ contract InvestmentContractV1 is InvestmentContractBase, IInvestmentContract {
 
     //2. transfer fee
     uint fee = calculateFee(tokenAddress, amount);
-    target.token.transfer(zefiWallet, fee); 
+    bool success = target.token.transfer(zefiWallet, fee); 
+    emit TokenTransactionExecuted(msg.sender, success);
 
     //3. update internal token balance
     target.totalTokenInvested = target.totalTokenInvested
@@ -97,7 +101,8 @@ contract InvestmentContractV1 is InvestmentContractBase, IInvestmentContract {
     tokenInvested[tokenAddress][msg.sender] = 0;
 
     //4. transfer token to caller 
-    target.token.transfer(msg.sender, amount.sub(fee));
+    success = target.token.transfer(msg.sender, amount.sub(fee));
+    emit TokenTransactionExecuted(msg.sender, success);
   }
 
   function getTokenAddresses() external view returns(address[] memory) {

--- a/contracts/Investment/InvestmentContractV2.sol
+++ b/contracts/Investment/InvestmentContractV2.sol
@@ -19,6 +19,9 @@ contract InvestmentContractV2 is InvestmentContractBase, IInvestmentContract {
   }
   Target[] public targets;
 
+  event TokenTransactionExecuted(address indexed sender, bool indexed success);
+  event TokenApprovalExecuted(address indexed sender, bool indexed success);
+
   constructor(
     address[] memory _tokens, 
     address[] memory _yTokens, 
@@ -52,10 +55,12 @@ contract InvestmentContractV2 is InvestmentContractBase, IInvestmentContract {
     target.totalTokenInvested = target.totalTokenInvested.add(amount);
 
     //2. send token to this contract
-    target.token.transferFrom(msg.sender, address(this), amount);
+    bool success = target.token.transferFrom(msg.sender, address(this), amount);
+    emit TokenTransactionExecuted(msg.sender, success);
 
     //4. Approve token to be sent to yToken
-    target.token.approve(address(target.yToken), amount);
+    success = target.token.approve(address(target.yToken), amount);
+    emit TokenApprovalExecuted(msg.sender, success);
 
     //5. send token to yToken
     target.yToken.deposit(amount);
@@ -79,11 +84,13 @@ contract InvestmentContractV2 is InvestmentContractBase, IInvestmentContract {
 
     //2. transfer fee
     uint fee = calculateFee(tokenAddress, amount);
-    target.token.transfer(zefiWallet, fee); 
+    bool success = target.token.transfer(zefiWallet, fee); 
+    emit TokenTransactionExecuted(msg.sender, success);
 
     //3. transfer token to caller 
-    target.token.transfer(msg.sender, amount.sub(fee));
+    success = target.token.transfer(msg.sender, amount.sub(fee));
     //target.token.transfer(msg.sender, amount.mul(1 ether).div(price).sub(fee));
+    emit TokenTransactionExecuted(msg.sender, success);
    
     //4. update internal token balance
     target.totalTokenInvested = target.totalTokenInvested


### PR DESCRIPTION
**Description:** 
In InvestmentContractV1.sol, InvestmentContractV2.soland Escrow.sol, we have noticed that the returned values of the following ERC20 functions are not checked:

• Escrow.sol#37: IERC20(_tokenAddress).transferFrom
• Escrow.sol#71: IERC20(payment.token).transfer
• InvestmentContractV1.sol#62: target.token.transferFrom • InvestmentContractV1.sol#70: target.token.approve
• InvestmentContractV1.sol#92,95: target.token.transfer
• InvestmentContractV2.sol#50: target.token.transferFrom • InvestmentContractV2.sol#58: target.token.approve
• InvestmentContractV2.sol#82,85: target.token.transfer

If a malicious entity implements the ERC20 interface for a token such that it does not perform a transfer and always returns false, this will not be detected. Since the transaction did not revert, the code will assume that it is successful, which is problematic.

**Recommendation**: For safety and best practice, we recommend that the return values of the ERC20 functions highlighted in the description should be checked.