### PR TITLE
QSP-6 Unchecked Input Validation of Address 0x0

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -34,6 +34,7 @@ contract Escrow {
     external 
     payable 
   {
+    require(_tokenAddress != address(0x0), "Escrow: Invalid Address");
     IERC20(_tokenAddress).transferFrom(msg.sender, address(this), _value); 
     _createPayment(
       _paymentTokenHash,
@@ -60,6 +61,7 @@ contract Escrow {
   }
 
   function sendPayment(bytes32 _paymentToken, address payable _to) external {
+    require(_to != address(0x0), "Escrow: Invalid Address");
     bytes32 paymentTokenHash = keccak256(abi.encodePacked(_paymentToken));
     Payment storage payment = payments[paymentTokenHash];
     require(payment.value != 0, 'wrong _paymentToken'); 

--- a/contracts/Investment/InvestmentContractV1.sol
+++ b/contracts/Investment/InvestmentContractV1.sol
@@ -38,6 +38,8 @@ contract InvestmentContractV1 is InvestmentContractBase, IInvestmentContract {
   ) public {
     require(_tokens.length == _cTokens.length, 'tokens and cTokens must have same length');
     for(uint i = 0; i < _tokens.length; i++) {
+      require(_tokens[i] != address(0x0), "Escrow: Invalid Address");
+      require(_cTokens[i] != address(0x0), "Escrow: Invalid Address");
       targets.push(Target(
         IERC20(_tokens[i]),
         ICToken(_cTokens[i]),

--- a/contracts/Investment/InvestmentContractV2.sol
+++ b/contracts/Investment/InvestmentContractV2.sol
@@ -26,6 +26,8 @@ contract InvestmentContractV2 is InvestmentContractBase, IInvestmentContract {
   ) public {
     require(_tokens.length == _yTokens.length, 'tokens and yTokens must have same length');
     for(uint i = 0; i < _tokens.length; i++) {
+      require(_tokens[i] != address(0x0), "Escrow: Invalid Address");
+      require(_yTokens[i] != address(0x0), "Escrow: Invalid Address");
       targets.push(Target(
         IERC20(_tokens[i]),
         IYToken(_yTokens[i]),
@@ -105,6 +107,7 @@ contract InvestmentContractV2 is InvestmentContractBase, IInvestmentContract {
   }
 
   function balanceOf(address owner) external view returns(uint[] memory) {
+    require(owner != address(0x0), "Escrow: Invalid Address");
     uint[] memory balances = new uint[](targets.length);
     for(uint i = 0; i < targets.length; i++) {
       balances[i] = _balanceOf(targets[i], owner);


### PR DESCRIPTION
**Description**: It is rarely desirable for a token to use the 0x0 address (although intentional token burning is a notable exception). However, these mistakes are often made due to human errors. Hence, it is usually a good idea to prevent these mistakes from happening within the smart contract by adding validation to check for 0x0 address inputs. Currently, checks for 0x0 address are missing in the following:

• Escrow.sol: The _tokenAddress parameter in function createTokenPayment
• Escrow.sol: The _to parameter in function sendPayment
• InvestmentContractV1.sol: Addresses inside the arrays _tokens and _cTokens in the constructor • InvestmentContractV1.sol: The owner parameter in function balanceOf
• InvestmentContractV2.sol: Addresses inside the arrays _tokens and _yTokens in the constructor • InvestmentContractV2.sol: The owner parameter in function balanceOf

**Recommendation**: An addition of a require statement to check for the argument of address 0x0 in the stated parameters is recommended.
