### PR TITLE
Meta Transaction Relayer

### DIFF
--- a/contracts/modules/Compound.sol
+++ b/contracts/modules/Compound.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.7;
 
 import "./common/BaseModule.sol";
+import "./common/RelayerModule.sol";
 import "./common/OnlyOwnerModule.sol";
 import "./utils/CompoundRegistry.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -28,7 +29,7 @@ interface ICToken {
  * @title Compound
  * @dev Module to invest tokens in Compound
  */
-contract Compound is BaseModule, OnlyOwnerModule {
+contract Compound is BaseModule, RelayerModule, OnlyOwnerModule {
     bytes32 constant NAME = "Compound";
 
     // The Compound IComptroller contract

--- a/contracts/modules/common/OnlyOwnerModule.sol
+++ b/contracts/modules/common/OnlyOwnerModule.sol
@@ -1,12 +1,14 @@
 pragma solidity ^0.5.7;
 import "./BaseModule.sol";
+import "./RelayerModule.sol";
 import "../../Wallet/BaseWallet.sol";
 
 /**
  * @title OnlyOwnerModule
- * @dev Module that extends BaseModule
+ * @dev Module that extends BaseModule and RelayerModule for modules where the execute() method
+ * must be called with one signature frm the owner.
  */
-contract OnlyOwnerModule is BaseModule {
+contract OnlyOwnerModule is BaseModule, RelayerModule {
 
     // bytes4 private constant IS_ONLY_OWNER_MODULE = bytes4(keccak256("isOnlyOwnerModule()"));
 
@@ -32,26 +34,26 @@ contract OnlyOwnerModule is BaseModule {
 
     // *************** Implementation of RelayerModule methods ********************* //
 
-    // // Overrides to use the incremental nonce and save some gas
-    // function checkAndUpdateUniqueness(BaseWallet _wallet, uint256 _nonce, bytes32 /* _signHash */) internal returns (bool) {
-    //     return checkAndUpdateNonce(_wallet, _nonce);
-    // }
+    // Overrides to use the incremental nonce and save some gas
+    function checkAndUpdateUniqueness(BaseWallet _wallet, uint256 _nonce, bytes32 /* _signHash */) internal returns (bool) {
+        return checkAndUpdateNonce(_wallet, _nonce);
+    }
 
-    // function validateSignatures(
-    //     BaseWallet _wallet,
-    //     bytes memory /* _data */,
-    //     bytes32 _signHash,
-    //     bytes memory _signatures
-    // )
-    //     internal
-    //     view
-    //     returns (bool)
-    // {
-    //     address signer = recoverSigner(_signHash, _signatures, 0);
-    //     return isOwner(_wallet, signer); // "OOM: signer must be owner"
-    // }
+    function validateSignatures(
+        BaseWallet _wallet,
+        bytes memory /* _data */,
+        bytes32 _signHash,
+        bytes memory _signatures
+    )
+        internal
+        view
+        returns (bool)
+    {
+        address signer = recoverSigner(_signHash, _signatures, 0);
+        return isOwner(_wallet, signer); // "OOM: signer must be owner"
+    }
 
-    // function getRequiredSignatures(BaseWallet /* _wallet */, bytes memory /* _data */) internal view returns (uint256) {
-    //     return 1;
-    // }
+    function getRequiredSignatures(BaseWallet /* _wallet */, bytes memory /* _data */) internal view returns (uint256) {
+        return 1;
+    }
 }

--- a/contracts/modules/common/RelayerModule.sol
+++ b/contracts/modules/common/RelayerModule.sol
@@ -1,0 +1,252 @@
+pragma solidity ^0.5.7;
+import "../../Wallet/BaseWallet.sol";
+import "../../interfaces/Module.sol";
+import "./BaseModule.sol";
+
+/**
+ * @title RelayerModule
+ * @dev Base module containing logic to execute transactions signed by eth-less accounts and sent by a relayer.
+ */
+contract RelayerModule is BaseModule {
+
+    uint256 constant internal BLOCKBOUND = 10000;
+
+    mapping (address => RelayerConfig) public relayer;
+
+    struct RelayerConfig {
+        uint256 nonce;
+        mapping (bytes32 => bool) executedTx;
+    }
+
+    event TransactionExecuted(address indexed wallet, bool indexed success, bytes32 signedHash);
+
+    /**
+     * @dev Throws if the call did not go through the execute() method.
+     */
+    modifier onlyExecute {
+        require(msg.sender == address(this), "RM: must be called via execute()");
+        _;
+    }
+
+    /* ***************** Abstract method ************************* */
+
+    /**
+    * @dev Gets the number of valid signatures that must be provided to execute a
+    * specific relayed transaction.
+    * @param _wallet The target wallet.
+    * @param _data The data of the relayed transaction.
+    * @return The number of required signatures.
+    */
+    function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) internal view returns (uint256);
+
+    /**
+    * @dev Validates the signatures provided with a relayed transaction.
+    * The method MUST throw if one or more signatures are not valid.
+    * @param _wallet The target wallet.
+    * @param _data The data of the relayed transaction.
+    * @param _signHash The signed hash representing the relayed transaction.
+    * @param _signatures The signatures as a concatenated byte array.
+    */
+    function validateSignatures(
+        BaseWallet _wallet,
+        bytes memory _data,
+        bytes32 _signHash,
+        bytes memory _signatures) internal view returns (bool);
+
+    /* ************************************************************ */
+
+    /**
+    * @dev Executes a relayed transaction.
+    * @param _wallet The target wallet.
+    * @param _data The data for the relayed transaction
+    * @param _nonce The nonce used to prevent replay attacks.
+    * @param _signatures The signatures as a concatenated byte array.
+    * @param _gasPrice The gas price to use for the gas refund.
+    * @param _gasLimit The gas limit to use for the gas refund.
+    */
+    function execute(
+        BaseWallet _wallet,
+        bytes calldata _data,
+        uint256 _nonce,
+        bytes calldata _signatures,
+        uint256 _gasPrice,
+        uint256 _gasLimit
+    )
+        external
+        returns (bool success)
+    {
+        uint startGas = gasleft();
+        bytes32 signHash = getSignHash(address(this), address(_wallet), 0, _data, _nonce, _gasPrice, _gasLimit);
+        require(checkAndUpdateUniqueness(_wallet, _nonce, signHash), "RM: Duplicate request");
+        require(verifyData(address(_wallet), _data), "RM: the wallet authorized is different then the target of the relayed data");
+        uint256 requiredSignatures = getRequiredSignatures(_wallet, _data);
+        if ((requiredSignatures * 65) == _signatures.length) {
+            if (verifyRefund(_wallet, _gasLimit, _gasPrice, requiredSignatures)) {
+                if (requiredSignatures == 0 || validateSignatures(_wallet, _data, signHash, _signatures)) {
+                    // solium-disable-next-line security/no-call-value
+                    (success,) = address(this).call(_data);
+                    refund(_wallet, startGas - gasleft(), _gasPrice, _gasLimit, requiredSignatures, msg.sender);
+                }
+            }
+        }
+        emit TransactionExecuted(address(_wallet), success, signHash);
+    }
+
+    /**
+    * @dev Gets the current nonce for a wallet.
+    * @param _wallet The target wallet.
+    */
+    function getNonce(BaseWallet _wallet) external view returns (uint256 nonce) {
+        return relayer[address(_wallet)].nonce;
+    }
+
+    /**
+    * @dev Generates the signed hash of a relayed transaction according to ERC 1077.
+    * @param _from The starting address for the relayed transaction (should be the module)
+    * @param _to The destination address for the relayed transaction (should be the wallet)
+    * @param _value The value for the relayed transaction
+    * @param _data The data for the relayed transaction
+    * @param _nonce The nonce used to prevent replay attacks.
+    * @param _gasPrice The gas price to use for the gas refund.
+    * @param _gasLimit The gas limit to use for the gas refund.
+    */
+    function getSignHash(
+        address _from,
+        address _to,
+        uint256 _value,
+        bytes memory _data,
+        uint256 _nonce,
+        uint256 _gasPrice,
+        uint256 _gasLimit
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encodePacked(
+                "\x19Ethereum Signed Message:\n32",
+                keccak256(abi.encodePacked(byte(0x19), byte(0), _from, _to, _value, _data, _nonce, _gasPrice, _gasLimit))
+        ));
+    }
+
+    /**
+    * @dev Checks if the relayed transaction is unique.
+    * @param _wallet The target wallet.
+    * @param _nonce The nonce
+    * @param _signHash The signed hash of the transaction
+    */
+    function checkAndUpdateUniqueness(BaseWallet _wallet, uint256 _nonce, bytes32 _signHash) internal returns (bool) {
+        if (relayer[address(_wallet)].executedTx[_signHash] == true) {
+            return false;
+        }
+        relayer[address(_wallet)].executedTx[_signHash] = true;
+        return true;
+    }
+
+    /**
+    * @dev Checks that a nonce has the correct format and is valid.
+    * It must be constructed as nonce = {block number}{timestamp} where each component is 16 bytes.
+    * @param _wallet The target wallet.
+    * @param _nonce The nonce
+    */
+    function checkAndUpdateNonce(BaseWallet _wallet, uint256 _nonce) internal returns (bool) {
+        if (_nonce <= relayer[address(_wallet)].nonce) {
+            return false;
+        }
+        uint256 nonceBlock = (_nonce & 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000) >> 128;
+        if (nonceBlock > block.number + BLOCKBOUND) {
+            return false;
+        }
+        relayer[address(_wallet)].nonce = _nonce;
+        return true;
+    }
+
+    /**
+    * @dev Recovers the signer at a given position from a list of concatenated signatures.
+    * @param _signedHash The signed hash
+    * @param _signatures The concatenated signatures.
+    * @param _index The index of the signature to recover.
+    */
+    function recoverSigner(bytes32 _signedHash, bytes memory _signatures, uint _index) internal pure returns (address) {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        // we jump 32 (0x20) as the first slot of bytes contains the length
+        // we jump 65 (0x41) per signature
+        // for v we load 32 bytes ending with v (the first 31 come from s) then apply a mask
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            r := mload(add(_signatures, add(0x20,mul(0x41,_index))))
+            s := mload(add(_signatures, add(0x40,mul(0x41,_index))))
+            v := and(mload(add(_signatures, add(0x41,mul(0x41,_index)))), 0xff)
+        }
+        require(v == 27 || v == 28); // solium-disable-line error-reason
+        return ecrecover(_signedHash, v, r, s);
+    }
+
+    /**
+    * @dev Refunds the gas used to the Relayer.
+    * For security reasons the default behavior is to not refund calls with 0 or 1 signatures.
+    * @param _wallet The target wallet.
+    * @param _gasUsed The gas used.
+    * @param _gasPrice The gas price for the refund.
+    * @param _gasLimit The gas limit for the refund.
+    * @param _signatures The number of signatures used in the call.
+    * @param _relayer The address of the Relayer.
+    */
+    function refund(BaseWallet _wallet, uint _gasUsed, uint _gasPrice, uint _gasLimit, uint _signatures, address _relayer) internal {
+        uint256 amount = 29292 + _gasUsed; // 21000 (transaction) + 7620 (execution of refund) + 672 to log the event + _gasUsed
+        // only refund if gas price not null, more than 1 signatures, gas less than gasLimit
+        if (_gasPrice > 0 && _signatures > 1 && amount <= _gasLimit) {
+            if (_gasPrice > tx.gasprice) {
+                amount = amount * tx.gasprice;
+            } else {
+                amount = amount * _gasPrice;
+            }
+            invokeWallet(address(_wallet), _relayer, amount, EMPTY_BYTES);
+        }
+    }
+
+    /**
+    * @dev Returns false if the refund is expected to fail.
+    * @param _wallet The target wallet.
+    * @param _gasUsed The expected gas used.
+    * @param _gasPrice The expected gas price for the refund.
+    */
+    function verifyRefund(BaseWallet _wallet, uint _gasUsed, uint _gasPrice, uint _signatures) internal view returns (bool) {
+        if (_gasPrice > 0 &&
+            _signatures > 1 &&
+            (address(_wallet).balance < _gasUsed * _gasPrice || _wallet.authorised(address(this)) == false)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+    * @dev Checks that the wallet address provided as the first parameter of the relayed data is the same
+    * as the wallet passed as the input of the execute() method.
+    @return false if the addresses are different.
+    */
+    function verifyData(address _wallet, bytes memory _data) private pure returns (bool) {
+        require(_data.length >= 36, "RM: Invalid dataWallet");
+        address dataWallet;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            //_data = {length:32}{sig:4}{_wallet:32}{...}
+            dataWallet := mload(add(_data, 0x24))
+        }
+        return dataWallet == _wallet;
+    }
+
+    /**
+    * @dev Parses the data to extract the method signature.
+    */
+    function functionPrefix(bytes memory _data) internal pure returns (bytes4 prefix) {
+        require(_data.length >= 4, "RM: Invalid functionPrefix");
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            prefix := mload(add(_data, 0x20))
+        }
+    }
+}


### PR DESCRIPTION
It is implemented for both Transfer Module and Compound Protocol where users needs not have to keep ETH to pay gas in their account.

### Test cases with Meta Transactions:

**Zefi Transfer Test Cases**

```
 TransferManager
ETH and ERC20 transfers
      ✓ should let the owner send ETH (208ms)
      ✓ should let the owner send ERC20 (177ms)
    ETH and ERC20 transfers through Meta transaction relayer
      ✓ should let the owner send ETH (157ms)
      ✓ should let the owner send ERC20 (422ms)
    ERC20 Token Approvals
      ✓ should appprove an ERC20 (136ms)
      ✓ should not appprove an ERC20 transfer when the signer is not the owner  (997ms)
```

**Compound Protocol Test Cases**

```
Invest Manager with Compound
Environment
      ✓ should deploy the environment correctly (112ms)
    Investment
      Add Investment
        ✓ should invest in ERC20 for 1 year and gain interests (1587ms)
        ✓ should invest in ETH for 1 year and gain interests (1196ms)
      Remove Investment
        ✓ should remove 20% of an ERC20 investment (1833ms)
        ✓ should remove 20% of an ERC20 investment (1525ms)
        ✓ should remove 20% of an ETH investment (2062ms)
        ✓ should remove 20% of an ETH investment (1591ms)
        ✓ should remove 40% of an ERC20 investment (1836ms)
        ✓ should remove 40% of an ERC20 investment (1567ms)
        ✓ should remove 40% of an ETH investment (1681ms)
        ✓ should remove 40% of an ETH investment (1746ms)
    Investment through meta transaction relayer
      Add Investment
        ✓ should invest in ERC20 for 1 year and gain interests (1838ms)
        ✓ should invest in ETH for 1 year and gain interests (1572ms)
      Remove Investment
        ✓ should remove 20% of an ERC20 investment (1622ms)
        ✓ should remove 20% of an ERC20 investment (2261ms)
        ✓ should remove 20% of an ETH investment (6703ms)
        ✓ should remove 20% of an ETH investment (1827ms)
        ✓ should remove 40% of an ERC20 investment (1953ms)
        ✓ should remove 40% of an ERC20 investment (2078ms)
        ✓ should remove 40% of an ETH investment (1846ms)
        ✓ should remove 40% of an ETH investment (1877ms)